### PR TITLE
Update rename-scaffold.ps1

### DIFF
--- a/tools/rename-scaffold.ps1
+++ b/tools/rename-scaffold.ps1
@@ -4,8 +4,8 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$scriptRoot = Get-Location
-$srcDir = Join-Path $scriptRoot "src"
+$workingDir = Get-Location
+$srcDir = Join-Path $workingDir "src"
 
 if (-not (Test-Path $srcDir)) {
     Write-Host "ERROR: src directory not found" -ForegroundColor Red

--- a/tools/rename-scaffold.ps1
+++ b/tools/rename-scaffold.ps1
@@ -4,7 +4,7 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$scriptRoot = $PSScriptRoot
+$scriptRoot = Get-Location
 $srcDir = Join-Path $scriptRoot "src"
 
 if (-not (Test-Path $srcDir)) {


### PR DESCRIPTION
修复在项目根目录运行 tools\rename-scaffold.ps1 会遇到 src 目录找不到的问题。
原代码会在 tools 下找 src，而非项目根目录下。